### PR TITLE
use Invariant as a functor

### DIFF
--- a/src/invariant.jl
+++ b/src/invariant.jl
@@ -21,7 +21,7 @@ function Invariant(fn, title::String; description = nothing, inputfn = identity,
     Invariant(; fn, title, description, inputfn, format)
 end
 
-(inv::Invariant)(x) = satisfies(inv, x)
+(inv::Invariant)(args...) = check(inv, args...)
 
 title(inv::Invariant) = inv.format(inv.title)
 description(inv::Invariant) =

--- a/src/invariant.jl
+++ b/src/invariant.jl
@@ -21,6 +21,7 @@ function Invariant(fn, title::String; description = nothing, inputfn = identity,
     Invariant(; fn, title, description, inputfn, format)
 end
 
+(inv::Invariant)(x) = satisfies(inv, x)
 
 title(inv::Invariant) = inv.format(inv.title)
 description(inv::Invariant) =

--- a/test/InvariantsCoreTests.jl
+++ b/test/InvariantsCoreTests.jl
@@ -24,6 +24,7 @@ function testinvariant(inv, input)
     @test_nowarn title(inv)
     @test_nowarn description(inv)
     @test_nowarn satisfies(inv, input)
+    @test_nowarn inv(input)
 end
 
 # ## Tests


### PR DESCRIPTION
This PR allows using `Invariant` as a functor.

The idea is packages can call invariants without depending on or even knowing about InvariantsCore.jl, just by calling them as a function on the object to check.